### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ https://www.kernel.org/doc/Documentation/i2c/dev-interface
 libc = "*"
 bitflags = "*"
 byteorder = "*"
-nix = "^0.3.6"
+nix = "0.4.0"


### PR DESCRIPTION
Simple change of the version of nix, we are now at 0.4.0.  This fixes the compilation error on line 188 and 189 in ffi.rs